### PR TITLE
RHEL Agent

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -1,0 +1,18 @@
+DEPENDENCIES
+  opsview_client
+    path: .
+    metadata: true
+  opsview_client_test
+    path: test/fixtures/cookbooks/opsview_client_test
+
+GRAPH
+  build-essential (2.2.3)
+  opsview_client (0.3.0)
+    build-essential (~> 2.2.3)
+    yum (~> 3.5.4)
+    yum-epel (~> 0.6.0)
+  opsview_client_test (0.2.1)
+    opsview_client (>= 0.0.0)
+  yum (3.5.4)
+  yum-epel (0.6.0)
+    yum (~> 3.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ opsview_client CHANGELOG
 
 This file is used to list changes made in each version of the opsview_client cookbook.
 
+0.3.0
+-----
+- Tenyo Grozev - Added setup_rhel_agent recipe; added build-essential, yum and yum-epel dependencies
+
 0.2.1
 -----
 - Rob Coward - Fixed #3 where updates are not being passed to opsview

--- a/README.md
+++ b/README.md
@@ -59,6 +59,124 @@ Attributes
   </tr>
 </table>
 
+#### opsview_client::setup_rhel_agent
+<table>
+  <tr>
+    <th>Key</th>
+    <th>Type</th>
+    <th>Description</th>
+    <th>Default</th>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['installation_method']</tt></td>
+    <td>String</td>
+    <td>Installation method for the agent - set up a yum repo, or assume it already exists (local)</td>
+    <td><tt>repo</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['packages']</tt></td>
+    <td>Hash</td>
+    <td>Packages (and specific versions, if needed) to install</td>
+    <td><tt>{ 'libmcrypt' => nil, 'opsview-agent' => nil }</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['conf_dir']</tt></td>
+    <td>String</td>
+    <td>Directory where the opsview-agent config files are</td>
+    <td><tt>/usr/local/nagios/etc</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['log_facility']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - syslog facility that should be used for logging</td>
+    <td><tt>daemon</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['pid_file']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - pid file for the opsview-agent process</td>
+    <td><tt>/var/tmp/nrpe.pid</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['server_port']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - what port the agent will listen on</td>
+    <td><tt>5666</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['server_address']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - what IP address to bind to</td>
+    <td><tt>0.0.0.0</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['nrpe_user']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - user to run as</td>
+    <td><tt>nagios</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['nrpe_group']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - group to run as</td>
+    <td><tt>nagios</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['allowed_hosts']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - comma-separated list of allowed host IPs</td>
+    <td><tt>127.0.0.1</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['dont_blame_nrpe']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - Whether to allow command arguments (1 to allow)</td>
+    <td><tt>1</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['debug']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - Whether to log debug messages</td>
+    <td><tt>0</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['command_timeout']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - max number of seconds allowed for plugins to finish</td>
+    <td><tt>60</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['connection_timeout']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - max number of seconds the agent will wait for connections to get established</td>
+    <td><tt>300</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['allow_weak_random_seed']</tt></td>
+    <td>String</td>
+    <td>nrpe.cfg parameter - whether to use pseudo random generator if /dev/[u]random unavailable</td>
+    <td><tt>1</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['include_dirs']</tt></td>
+    <td>List</td>
+    <td>nrpe.cfg parameter - List of include directories to scan for cfg files</td>
+    <td><tt>/usr/local/nagios/etc/nrpe_local</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['include_files']</tt></td>
+    <td>List</td>
+    <td>nrpe.cfg parameter - List of additional cfg files to include</td>
+    <td><tt>BLANK</tt></td>
+  </tr>
+  <tr>
+    <td><tt>['opsview']['agent']['default_commands']</tt></td>
+    <td>Boolean</td>
+    <td>nrpe.cfg parameter - Whether to define the default check commands, such as check_load and check_disk</td>
+    <td><tt>true</tt></td>
+  </tr>
+</table>
+
 Usage
 -----
 #### opsview_client::default
@@ -79,7 +197,7 @@ Just include `opsview_client` in your node's `run_list`:
 Include this resource in your recipe to have the host dynamically registered with OpsView.
 
 ```ruby
-opsview_client node['fqdn'] do 
+opsview_client node['fqdn'] do
   api_user 'userid'
   api_password 'passw0rd'
   api_protocol 'http'
@@ -103,18 +221,15 @@ Contributing
 
 License and Authors
 -------------------
-Authors: Rob Coward
+Authors:
+  * Rob Coward
+  * Tenyo Grozev (tenyo.grozev@yale.edu)
 
 Copyright 2015 New Voice Media
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at
 
 http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,84 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.require_version '>= 1.5.0'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  # All Vagrant configuration is done here. The most common configuration
+  # options are documented and commented below. For a complete reference,
+  # please see the online documentation at vagrantup.com.
+
+  config.vm.hostname = 'opsview-client'
+
+  # Set the version of chef to install using the vagrant-omnibus plugin
+  # NOTE: You will need to install the vagrant-omnibus plugin:
+  #
+  #   $ vagrant plugin install vagrant-omnibus
+  #
+  if Vagrant.has_plugin? "vagrant-omnibus"
+    config.omnibus.chef_version = 'latest'
+  end
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  # If this value is a shorthand to a box in Vagrant Cloud then
+  # config.vm.box_url doesn't need to be specified.
+  config.vm.box = 'opscode-centos-6.6'
+
+
+  # Assign this VM to a host-only network IP, allowing you to access it
+  # via the IP. Host-only networks can talk to the host machine as well as
+  # any other machines on the same network, but cannot be accessed (through this
+  # network interface) by any external networks.
+  config.vm.network :private_network, ip: '192.168.33.33'
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider :virtualbox do |vb|
+  #   # Don't boot with headless mode
+  #   vb.gui = true
+  #
+  #   # Use VBoxManage to customize the VM. For example to change memory:
+  #   vb.customize ["modifyvm", :id, "--memory", "1024"]
+  # end
+  #
+  # View the documentation for the provider you're using for more
+  # information on available options.
+
+  # The path to the Berksfile to use with Vagrant Berkshelf
+  # config.berkshelf.berksfile_path = "./Berksfile"
+
+  # Enabling the Berkshelf plugin. To enable this globally, add this configuration
+  # option to your ~/.vagrant.d/Vagrantfile file
+  config.berkshelf.enabled = true
+
+  # An array of symbols representing groups of cookbook described in the Vagrantfile
+  # to exclusively install and copy to Vagrant's shelf.
+  # config.berkshelf.only = []
+
+  # An array of symbols representing groups of cookbook described in the Vagrantfile
+  # to skip installing and copying to Vagrant's shelf.
+  # config.berkshelf.except = []
+
+  # Uncomment section below to provision with Chef Solo
+  config.vm.provision :chef_solo do |chef|
+    chef.run_list = [
+      'recipe[opsview_client::default]'
+    ]
+  end
+
+end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,9 @@
 # limitations under the License.
 #
 
+# override build-essential attribute
+default['build-essential']['compile_time'] = true
+
 default['opsview']['server_url'] = 'uat.opsview.com'
 default['opsview']['server_port'] = '443'
 default['opsview']['server_protocol'] = 'https'

--- a/attributes/setup_rhel_agent.rb
+++ b/attributes/setup_rhel_agent.rb
@@ -1,0 +1,31 @@
+# select the installation method for the Opsview agent
+# the default 'repo' will set up a yum repo pointing to the Opsview Core repository
+# set to 'local' if you want to handle the package repo yourself (e.g. if you're wrapping this cookbook and using a Satellite server)
+default['opsview']['agent']['installation_method'] = 'repo'
+
+# specify which packages (and specific versions, if needed) to install
+default['opsview']['agent']['packages'] = {
+  'libmcrypt' => nil,
+  'opsview-agent' => nil
+}
+
+# config directory
+default['opsview']['agent']['conf_dir'] = '/usr/local/nagios/etc'
+
+# nrpe config parameters
+default['opsview']['agent']['log_facility'] = 'daemon'
+default['opsview']['agent']['pid_file'] = '/var/tmp/nrpe.pid'
+default['opsview']['agent']['server_port'] = '5666'
+default['opsview']['agent']['server_address'] = '0.0.0.0'
+default['opsview']['agent']['nrpe_user'] = 'nagios'
+default['opsview']['agent']['nrpe_group'] = 'nagios'
+default['opsview']['agent']['allowed_hosts'] = '127.0.0.1'
+default['opsview']['agent']['dont_blame_nrpe'] = '1'
+default['opsview']['agent']['debug'] = '0'
+default['opsview']['agent']['command_timeout'] = '60'
+default['opsview']['agent']['connection_timeout'] = '300'
+default['opsview']['agent']['allow_weak_random_seed'] = '1'
+default['opsview']['agent']['include_dirs'] = [ "#{node['opsview']['agent']['conf_dir']}/nrpe_local" ]
+default['opsview']['agent']['include_files'] = [ ]
+default['opsview']['agent']['default_commands'] = true
+

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,11 @@ maintainer_email 'rob@coward-family.net'
 license          'Apache 2.0'
 description      'Installs/Configures opsview agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.2.1'
+version          '0.3.0'
+
+depends 'build-essential', '~> 2.2.3'
+depends 'yum', '~> 3.5.4'
+depends 'yum-epel', '~> 0.6.0'
 
 %w(redhat centos windows).each do |os|
   supports os

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -17,9 +17,12 @@
 # limitations under the License.
 #
 
+# build-essential sets up prereqs for chef_gem
+include_recipe 'build-essential::default'
 chef_gem 'rest-client'
 chef_gem 'hashdiff'
 
+# install the appropriate Opsview agent
 case node['platform_family']
 when 'windows'
         include_recipe 'opsview_client::setup_windows_agent'

--- a/recipes/setup_rhel_agent.rb
+++ b/recipes/setup_rhel_agent.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: opsview_client
 # Recipe:: setup_rhel_agent
 #
-# Copyright 2014, Rob Coward
+# Author: Tenyo Grozev (tenyo.grozev@yale.edu)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,4 +16,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+if node['opsview']['agent']['installation_method'] == 'repo'
+
+  # add the epel repo, needed for the libmcrypt package
+  include_recipe "yum-epel::default"
+
+  yum_repository "opsview-core" do
+    description "Opsview Core"
+    gpgcheck false
+    case node['platform']
+    when "redhat"
+      baseurl "http://downloads.opsview.com/opsview-core/latest/yum/rhel/$releasever/$basearch"
+    when "centos"
+      baseurl "http://downloads.opsview.com/opsview-core/latest/yum/centos/$releasever/$basearch"
+    end
+    action :create
+  end
+
+end
+
+# Install packages
+node['opsview']['agent']['packages'].each do |pkg,ver|
+  package pkg do
+    action :install
+    version ver if ver
+  end
+end
+
+template "#{node['opsview']['agent']['conf_dir']}/nrpe.cfg" do
+  source 'nrpe.cfg.erb'
+  mode '0444'
+  user node['opsview']['agent']['nrpe_user']
+  group node['opsview']['agent']['nrpe_group']
+  notifies :restart, 'service[opsview-agent]', :immediately
+end
+
+service "opsview-agent" do
+  action [ :enable, :start ]
+end
 

--- a/spec/unit/setup_rhel_agent.rb
+++ b/spec/unit/setup_rhel_agent.rb
@@ -1,0 +1,24 @@
+require_relative '../spec_helper.rb'
+
+describe 'opsview_client::setup_rhel_agent' do
+
+  let(:chef_run) { ChefSpec::SoloRunner.new do |node|
+    node.automatic['platform_family'] = 'rhel'
+  end.converge(described_recipe) }
+
+  packages = %w{ libmcrypt opsview-agent }
+  packages.each do |pkg|
+    it "installs package #{pkg}" do
+      expect(chef_run).to install_package(pkg)
+    end
+  end
+
+  it "creates nrpe.cfg template" do
+    expect(chef_run).to create_template('/usr/local/nagios/etc/nrpe.cfg')
+  end
+
+  it "starts service opsview-agent" do
+    expect(chef_run).to start_service("opsview-agent")
+  end
+
+end

--- a/templates/default/nrpe.cfg.erb
+++ b/templates/default/nrpe.cfg.erb
@@ -1,0 +1,222 @@
+#############################################################################
+# NRPE Config File for Opsview
+# Created by Chef
+#
+# NOTES:
+# This is the configuration file for the NRPE daemon.  It needs to be
+# located on the remote host that is running the NRPE daemon, not the host
+# from which the check_nrpe client is being executed.
+#############################################################################
+
+
+# LOG FACILITY
+# The syslog facility that should be used for logging purposes.
+
+log_facility=<%= node['opsview']['agent']['log_facility'] %>
+
+
+
+# PID FILE
+# The name of the file in which the NRPE daemon should write it's process ID
+# number.  The file is only written if the NRPE daemon is started by the root
+# user and is running in standalone mode.
+
+pid_file=<%= node['opsview']['agent']['pid_file'] %>
+
+
+
+# PORT NUMBER
+# Port number we should wait for connections on.
+# NOTE: This must be a non-priviledged port (i.e. > 1024).
+# NOTE: This option is ignored if NRPE is running under either inetd or xinetd
+
+server_port=<%= node['opsview']['agent']['server_port'] %>
+
+
+
+# SERVER ADDRESS
+# Address that nrpe should bind to in case there are more than one interface
+# and you do not want nrpe to bind on all interfaces.
+# NOTE: This option is ignored if NRPE is running under either inetd or xinetd
+
+server_address=<%= node['opsview']['agent']['server_address'] %>
+
+
+
+# NRPE USER
+# This determines the effective user that the NRPE daemon should run as.
+# You can either supply a username or a UID.
+#
+# NOTE: This option is ignored if NRPE is running under either inetd or xinetd
+
+nrpe_user=<%= node['opsview']['agent']['nrpe_user'] %>
+
+
+
+# NRPE GROUP
+# This determines the effective group that the NRPE daemon should run as.
+# You can either supply a group name or a GID.
+#
+# NOTE: This option is ignored if NRPE is running under either inetd or xinetd
+
+nrpe_group=<%= node['opsview']['agent']['nrpe_group'] %>
+
+
+
+# ALLOWED HOST ADDRESSES
+# This is an optional comma-delimited list of IP address or hostnames
+# that are allowed to talk to the NRPE daemon.
+#
+# Note: The daemon only does rudimentary checking of the client's IP
+# address.  I would highly recommend adding entries in your /etc/hosts.allow
+# file to allow only the specified host to connect to the port
+# you are running this daemon on.
+#
+# NOTE: This option is ignored if NRPE is running under either inetd or xinetd
+
+allowed_hosts=<%= node['opsview']['agent']['allowed_hosts'] %>
+
+
+
+# COMMAND ARGUMENT PROCESSING
+# This option determines whether or not the NRPE daemon will allow clients
+# to specify arguments to commands that are executed.  This option only works
+# if the daemon was configured with the --enable-command-args configure script
+# option.
+#
+# *** ENABLING THIS OPTION IS A SECURITY RISK! ***
+# Read the SECURITY file for information on some of the security implications
+# of enabling this variable.
+#
+# Values: 0=do not allow arguments, 1=allow command arguments
+
+dont_blame_nrpe=<%= node['opsview']['agent']['dont_blame_nrpe'] %>
+
+
+
+# COMMAND PREFIX
+# This option allows you to prefix all commands with a user-defined string.
+# A space is automatically added between the specified prefix string and the
+# command line from the command definition.
+#
+# *** THIS EXAMPLE MAY POSE A POTENTIAL SECURITY RISK, SO USE WITH CAUTION! ***
+# Usage scenario:
+# Execute restricted commmands using sudo.  For this to work, you need to add
+# the nagios user to your /etc/sudoers.  An example entry for alllowing
+# execution of the plugins from might be:
+#
+# nagios          ALL=(ALL) NOPASSWD: /usr/lib/nagios/plugins/
+#
+# This lets the nagios user run all commands in that directory (and only them)
+# without asking for a password.  If you do this, make sure you don't give
+# random users write access to that directory or its contents!
+
+# command_prefix=/usr/bin/sudo
+
+
+
+# DEBUGGING OPTION
+# This option determines whether or not debugging messages are logged to the
+# syslog facility.
+# Values: 0=debugging off, 1=debugging on
+
+debug=<%= node['opsview']['agent']['debug'] %>
+
+
+
+# COMMAND TIMEOUT
+# This specifies the maximum number of seconds that the NRPE daemon will
+# allow plugins to finish executing before killing them off.
+
+command_timeout=<%= node['opsview']['agent']['command_timeout'] %>
+
+
+
+# CONNECTION TIMEOUT
+# This specifies the maximum number of seconds that the NRPE daemon will
+# wait for a connection to be established before exiting. This is sometimes
+# seen where a network problem stops the SSL being established even though
+# all network sessions are connected. This causes the nrpe daemons to
+# accumulate, eating system resources. Do not set this too low.
+
+connection_timeout=<%= node['opsview']['agent']['connection_timeout'] %>
+
+
+
+# WEEK RANDOM SEED OPTION
+# This directive allows you to use SSL even if your system does not have
+# a /dev/random or /dev/urandom (on purpose or because the necessary patches
+# were not applied). The random number generator will be seeded from a file
+# which is either a file pointed to by the environment valiable $RANDFILE
+# or $HOME/.rnd. If neither exists, the pseudo random number generator will
+# be initialized and a warning will be issued.
+# Values: 0=only seed from /dev/[u]random, 1=also seed from weak randomness
+
+allow_weak_random_seed=<%= node['opsview']['agent']['allow_weak_random_seed'] %>
+
+
+
+# INCLUDE CONFIG FILE
+# This directive allows you to include definitions from an external config file.
+
+<% node['opsview']['agent']['include_files'].each do |file| %>
+include=<%= file %>
+<% end %>
+
+
+
+# INCLUDE CONFIG DIRECTORY
+# This directive allows you to include definitions from config files (with a
+# .cfg extension) in one or more directories (with recursion).
+
+<% node['opsview']['agent']['include_dirs'].each do |dir| %>
+include_dir=<%= dir %>
+<% end %>
+
+
+<% if node['opsview']['agent']['default_commands'] %>
+
+# COMMAND DEFINITIONS
+# Command definitions that this daemon will run.  Definitions
+# are in the following format:
+#
+# command[<command_name>]=<command_line>
+#
+# When the daemon receives a request to return the results of <command_name>
+# it will execute the command specified by the <command_line> argument.
+#
+# Unlike Nagios, the command line cannot contain macros - it must be
+# typed exactly as it should be executed.
+#
+# Note: Any plugins that are used in the command lines must reside
+# on the machine that this daemon is running on!  The examples below
+# assume that you have plugins installed in a /usr/local/nagios/libexec
+# directory.  Also note that you will have to modify the definitions below
+# to match the argument format the plugins expect.  Remember, these are
+# examples only!
+
+# All entries should be in the following form
+
+command[check_users]=/usr/local/nagios/libexec/check_users $ARG1$
+command[check_load]=/usr/local/nagios/libexec/check_load $ARG1$
+command[check_disk]=/usr/local/nagios/libexec/check_disk $ARG1$
+command[check_swap]=/usr/local/nagios/libexec/check_swap $ARG1$
+command[check_procs]=/usr/local/nagios/libexec/check_procs $ARG1$
+command[check_memory]=/usr/local/nagios/libexec/check_memory $ARG1$
+command[check_file_age]=/usr/local/nagios/libexec/check_file_age $ARG1$
+command[check_dir_age]=/usr/local/nagios/libexec/check_dir_age $ARG1$
+command[check_mailq]=/usr/local/nagios/libexec/check_mailq $ARG1$
+command[check_hpjd]=/usr/local/nagios/libexec/check_hpjd $ARG1$
+command[check_ntp]=/usr/local/nagios/libexec/check_ntp $ARG1$
+command[check_ntp_peer]=/usr/local/nagios/libexec/check_ntp_peer $ARG1$
+command[check_ntp_time]=/usr/local/nagios/libexec/check_ntp_time $ARG1$
+command[check_snmp]=/usr/local/nagios/libexec/check_snmp $ARG1$
+command[check_time]=/usr/local/nagios/libexec/check_time $ARG1$
+command[check_tcp]=/usr/local/nagios/libexec/check_tcp $ARG1$
+command[check_cluster]=/usr/local/nagios/libexec/check_cluster $ARG1$
+command[check_ide_smart]=/usr/local/nagios/libexec/check_ide_smart $ARG1$
+command[check_postgres]=/usr/local/nagios/libexec/check_postgres $ARG1$
+command[check_raid]=/usr/local/nagios/libexec/check_raid $ARG1$
+command[check_time_skew]=/usr/local/nagios/libexec/check_time_skew $ARG1$
+
+<% end %>


### PR DESCRIPTION
- Add setup_rhel_agent recipe to install and configure the opsview-client on RHEL/CentOS servers
- Add Chefspec test for setup_rhel_agent
- Add yum and yum-epel cookbook dependencies required for setup_rhel_agent
- Add build-essential dependency to install make, gcc packages needed for chef_gem
- Add Vagrantfile
- Bump cookbook version to 0.3.0
- Tested on RHEL6 and CentOS6
