### PR TITLE
add flush_cache to package installation in setup_rhel_agent.rb

### DIFF
--- a/Berksfile.lock
+++ b/Berksfile.lock
@@ -8,7 +8,7 @@ DEPENDENCIES
 GRAPH
   build-essential (2.2.3)
   chef_handler (1.2.0)
-  opsview_client (1.0.1)
+  opsview_client (1.0.2)
     build-essential (>= 0.0.0)
     windows (>= 0.0.0)
     yum (>= 0.0.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ opsview_client CHANGELOG
 
 This file is used to list changes made in each version of the opsview_client cookbook.
 
+1.0.2
+-----
+- Tenyo Grozev - Add flush_cache to package installation in setup_rhel_agent.rb
+
 1.0.1
 -----
 - Rob Coward - Removed version contraints from metadata.rb to allow newer versions to be used.

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'rob@coward-family.net'
 license          'Apache 2.0'
 description      'Installs/Configures opsview agent'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.0.1'
+version          '1.0.2'
 
 depends 'build-essential'
 depends 'yum'

--- a/recipes/setup_rhel_agent.rb
+++ b/recipes/setup_rhel_agent.rb
@@ -39,6 +39,7 @@ node['opsview']['agent']['packages'].each do |pkg,ver|
     action :install
     version ver if ver
     options '--nogpgcheck'
+    flush_cache before: true
   end
 end
 


### PR DESCRIPTION
This fixes the rare case where another repo already exists on the system, containing a different version of the opsview-agent package. Adding flush_cache makes sure the repository cache gets rebuilt before trying to install the package.
